### PR TITLE
search for other devices if GPU is not available

### DIFF
--- a/example/example1.cpp
+++ b/example/example1.cpp
@@ -14,8 +14,14 @@ int main()
 
 	if(device == NULL)
 	{
-		cout << "No device avliable. exiting" << endl;
-		exit(0);
+		device = deviceManager.defaultDevice(CL_DEVICE_TYPE_ALL);
+
+		if(device == NULL)
+		{
+			cout << "No device avliable. exiting" << endl;
+			exit(0);
+		}
+
 	}
 
 	cout << "selected device:" << endl;


### PR DESCRIPTION
search for other devices if GPU is not available

By default we search GPU only and exit if it is unavailable.
In some cases, machines have noly CPU or UMA so there is not discrete gfx and should switch to use the internal gfx.
